### PR TITLE
Replaced the (typeof == 'object') check with a comparison to null

### DIFF
--- a/src/vcompiler.js
+++ b/src/vcompiler.js
@@ -59,7 +59,7 @@ VCP.assemble = function(options){
 			if( parentParentIsNotEXP && index === 0 && isHomogenous ){
 
 				if(escapeStack.length === 0){
-					start += '( typeof (__vt = ';
+					start += '( (__vt = ';
 				}
 			}
 
@@ -68,7 +68,7 @@ VCP.assemble = function(options){
 				if(escapeStack.length > 0){
 					escapeStack.pop();
 				} else {
-					end += ") !== 'undefined' ? __vt : '' ).toString()\n"
+					end += ") != null ? __vt : '' ).toString()\n"
 						+ ".replace(__ampre, __amp)\n"
 						+ ".replace(__ltre, __lt)\n"
 						+ ".replace(__gtre, __gt)\n"


### PR DESCRIPTION
I figure that check was there to make sure .toString() could be called, but typeof null == 'object'. I believe it is always the case that obj.toString() may be called if obj != null (and if there haven't been prototype shenanigans).
