### PR TITLE
typo fix: 'creme' should be 'cream'

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ input:
 
 output:
 
-	banana creme
+	banana cream
 
 As you can see, Vash does not require a model to be referenced, or even passed in.
 


### PR DESCRIPTION
I like 'creme' but here it should be 'cream', unless I did not understand the example ;-)