### PR TITLE
Pass model in highlight helper

### DIFF
--- a/lib/helpers/highlight.js
+++ b/lib/helpers/highlight.js
@@ -15,7 +15,7 @@ helpers.highlight = function(lang, cb){
 
   // cb() is simply a user-defined function. It could (and should) contain
   // buffer additions, so we call it...
-  cb();
+  cb( this.model );
 
   // ... and then use fromMark() to grab the output added by cb().
   var cbOutLines = this.buffer.fromMark(startMark);


### PR DESCRIPTION
Hello,

While comparing highlight and layout helpers, I spotted an inconsistency. I think you should pass model to callback of highlight helper for consistency with layout helper.

Regards,
Laurent Debacker