### PR TITLE
Adding MIT license ID to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.13.0",
   "author": "Andrew Petersen <senofpeter@gmail.com>",
   "homepage": "https://github.com/kirbysayshi/vash",
+  "license": "MIT",
   "bin": {
     "vash": "./bin/vash"
   },


### PR DESCRIPTION
README file already shows the license but adding it to package.json to make it even more obvious to package consumers as well as to license identification tooling.